### PR TITLE
changed threadx-rust submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-[submodule "mcu_sw/threadx-rust"]
+[submodule "mcu_new/threadx-rust"]
 	path = mcu_sw/threadx-rust
-	url = git@github.com:gabriel-CBE/threadx-rust.git
+	url = git@github.com:Eclipse-SDV-Hackathon-Chapter-Three/threadx-rust.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,5 @@
     "rust-analyzer.linkedProjects": [
         "mcu_sw/threadx-rust/Cargo.toml",
         "mcu_sw/threadx-rust/threadx-app/cross/Cargo.toml",
-        "mcu_new/threadx-rust/Cargo.toml",
-        "mcu_new/threadx-rust/threadx-app/cross/Cargo.toml",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
     "rust-analyzer.linkedProjects": [
         "mcu_sw/threadx-rust/Cargo.toml",
         "mcu_sw/threadx-rust/threadx-app/cross/Cargo.toml",
+        "mcu_new/threadx-rust/Cargo.toml",
+        "mcu_new/threadx-rust/threadx-app/cross/Cargo.toml",
     ]
 }

--- a/mcu_sw/README.md
+++ b/mcu_sw/README.md
@@ -3,7 +3,8 @@
 
 ## Overview
 
-This embedded Rust application runs on the MxChip IoT DevKit, implementing a real-time IoT sensor node using Azure RTOS ThreadX. The system automatically measures environmental data and communicates via MQTT over WiFi. Simultaneously it receives a RGB value via MQTT and sets the integrated LED
+This embedded Rust application runs on the MxChip IoT DevKit, implementing a real-time IoT sensor node using Azure RTOS ThreadX. The system automatically measures environmental data and communicates via MQTT over WiFi. Simultaneously it receives a RGB value via MQTT and sets the integrated LED.
+It's based on the threadx-rust repository, provided for the _Eclipse SDV Hackathon 2025_ with added drivers, to control the LED on the board.
 
 ## Features
 
@@ -38,20 +39,6 @@ This embedded Rust application runs on the MxChip IoT DevKit, implementing a rea
 - Message counter display (sent/received)
 - Last received/sent message preview
 - Button-triggered emergency messaging
-
-
-## System Architecture
-
-```
-┌─────────────────┐    ┌──────────────────┐
-│ Measurement     │    │ Network          │
-│ Thread          │───▶│ Thread           │
-│ - Read sensor   │    │ - WiFi/MQTT      │
-│ - Send to queue │    │ - Display update │
-└─────────────────┘    │ - LED control    │
-                       └──────────────────┘
-```
-
 
 ## Configuration
 
@@ -90,25 +77,3 @@ To build and run this project, navigate to the directory `threadx-rust/threadx-a
 - **ThreadX-rs**: Rust bindings for ThreadX API
 
 This system demonstrates modern embedded IoT development combining Rust's safety guarantees with real-time operating system capabilities for reliable sensor data collection and wireless communication.
-<span style="display:none">[^1][^2][^3][^4][^5][^6][^7][^8][^9]</span>
-
-<div align="center">⁂</div>
-
-[^1]: https://docs.rs/homie-controller
-
-[^2]: https://docs.rs/color-parser
-
-[^3]: https://docs.esp-rs.org/std-training/03_5_3_mqtt.html
-
-[^4]: https://crates.io/crates/mqtt-analyzer/dependencies
-
-[^5]: https://github.com/seancroach/hex_color
-
-[^6]: https://community.openhab.org/t/solved-mqtt-esphome-color-channel-integration/141824
-
-[^7]: https://www.tinkerforge.com/en/doc/Software/API_Bindings_MQTT.html
-
-[^8]: https://dev.to/emqx/how-to-use-mqtt-in-rust-5fne
-
-[^9]: https://crates.io/crates/csscolorparser
-


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->
## 🚀 Summary:
Changed submodule to threadx-rust hosted by Eclipse

## 🔍 Changes Made:  
- removed private fork of threadx-rust repo
- added eclipse hosted repo as submodule
- applied changes in branch "arbytesmoral/main"

## 🧠 Reasoning: 
No repository hosted on private accounts are allowed

## 🛠️ Testing:
- [x] no testing needed (e.g. Readme)
- [ ] local testing
- [ ] some intergation tests
- [ ] full integration tests

## 📋 Checklist:
- [ ] Code follows the project’s style guide
- [ ] Readme/Documentation updated
- [ ] License header added to each new file
- [ ] Tested